### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apk --update --no-cache add \
     php7-mbstring \
     php7-openssl \
     php7-session \
+    php7-sqlite3 \
     php7-xml \
     php7-zip \
     php7-zlib \


### PR DESCRIPTION
add sqlite3 for a lot of extensions in Dokuwiki like 404 manager, bez, strata, struct and more. Full list here: https://www.dokuwiki.org/fr:plugins?plugintag=sqlite