### PR TITLE
Add support for php81-dom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk --update --no-cache add \
     libgd \
     nginx \
     php81 \
+    php81-dom \
     php81-cli \
     php81-ctype \
     php81-curl \


### PR DESCRIPTION
The [Bulma template](https://github.com/KSU-Linux/dokuwiki-template-bulma) needs support for php81-dom or else it throws out this error

```
2023-02-12 13:16:51	/data/tpl/bulma/tpl_functions.php(57)	Error: Class "DOMDocument" not found
  #0 /data/tpl/bulma/main.php(86): _tpl_content()
  #1 /var/www/inc/actions.php(27): include('...')
  #2 /var/www/doku.php(126): act_dispatch()
  #3 {main}
```